### PR TITLE
TEST-123: WIP

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1,35 +1,15 @@
-# server.py
 from mcp.server.fastmcp import FastMCP
 import sys
 from tools.github_tools import find_or_create_pr
 
-# Create an MCP server
 mcp = FastMCP("Demo")
 
-
-# Add an addition tool
-@mcp.tool()
-def add(a: int, b: int) -> int:
-    """Add two numbers"""
-    print(f"Adding {a} and {b}", file=sys.stderr)
-    return a + b
-
-
-# Add a dynamic greeting resource
-@mcp.resource("greeting://{name}")
-def get_greeting(name: str) -> str:
-    """Get a personalized greeting"""
-    print(f"Greeting requested for {name}", file=sys.stderr)
-    return f"Hello, {name}!"
-
-# Add MCP test tool
 @mcp.tool()
 def mcp_test() -> str:
     """Test if MCP server is connected"""
     print("MCP connection test requested", file=sys.stderr)
     return "MCP 서버가 정상적으로 연결되었습니다! 🎉"
 
-# Add GitHub PR creation tool
 @mcp.tool()
 def github(issue_id: str = None, base: str = "main") -> str:
     """GitHub PR을 생성하거나 업데이트합니다"""
@@ -42,11 +22,11 @@ def github(issue_id: str = None, base: str = "main") -> str:
             return result["message"]
         elif result["status"] == "UPDATED":
             return f"PR이 업데이트되었습니다: {result['url']}"
-        else:  # CREATED
+        else: 
             return f"새 PR이 생성되었습니다: {result['url']}"
     except Exception as e:
         return f"오류가 발생했습니다: {str(e)}"
 
 if __name__ == "__main__":
     print("MCP 서버가 시작됩니다...", file=sys.stderr)
-    mcp.run()  # 서버 실행
+    mcp.run()  


### PR DESCRIPTION
<!-- devflow-mcp-start -->
## 🛠 devflow-mcp 업데이트
- 관련 이슈: TEST-123
- 병합 대상 브랜치: main
- 업데이트 시간: 2025.05-28 07:29:06

## 작업 요약
## 🧾 Overview
이 풀 리퀘스트에서는 `mcp_server.py` 파일을 간소화하였습니다. 불필요한 서버 도구들을 제거하고 서버 실행에 집중하는 코드로 재구성하였습니다.

## 🧩 History

**[현상]**
- 기존 `mcp_server.py` 파일의 코드는 복잡하고 여러 도구들이 많았습니다. 이 도구들은 `mcp_server`의 주요 기능과 직접적인 연관이 없었으며, 코드 이해 및 유지 보수 측면에서 부담이었습니다.

**[원인]**
- 코드가 성장하면서 여러 테스트 및 사례 도구들이 추가되었으나, 이들이 `mcp_server`의 주요 책임과는 맞지 않아 코드를 이해하는데 방해가 되었습니다.

**[해결]**
- 복잡성을 줄이고 코드의 주요 목적에 집중하기 위해, `add`와 `get_greeting` 도구 함수를 제거하였습니다. 이제 `mcp_server.py`는 `mcp_test`와 `github` 도구 함수만을 유지합니다. 이 두 도구는 MCP 서버의 연결 상태를 테스트하고 GitHub PR을 생성하는 핵심 기능을 수행합니다.

## 📝 Note
- 제거된 도구 함수들의 기능은 필요 시 다른 파일에서 구현되어야 합니다. 
- 리뷰시 제거된 코드와 남아 있는 도구 함수들이 적절하게 선택되었는지 확인해 주세요.
- 향후, `mcp_server.py`의 역할과 책임이 더욱 확실히 정의되어야 할 필요가 있습니다.

🔧 자동으로 생성된 내용입니다.

🔧 자동으로 생성된 내용입니다.
<!-- devflow-mcp-end -->