### PR TITLE
TEST-123: WIP

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -14,8 +14,13 @@ def mcp_test() -> str:
 def github(issue_id: str = None, base: str = "main") -> str:
     """GitHub PR을 생성하거나 업데이트합니다"""
     if not issue_id:
-        return "이슈 ID를 입력해주세요. 예: /github issue_id=ABC-123"
-    
+        issue_id = input("이슈 ID를 입력해주세요 (예: ABC-123): ").strip()
+        if not issue_id:
+            return "이슈 ID가 필요합니다."
+    if not base or base == "main":
+        base_input = input("PR 생성시 기준이 될 브랜치명을 입력하세요 (기본값: main): ").strip()
+        if base_input:
+            base = base_input
     try:
         result = find_or_create_pr(issue_id, base)
         if result["status"] == "BRANCH_NOT_FOUND":


### PR DESCRIPTION
<!-- devflow-mcp-start -->
## 🛠 devflow-mcp 업데이트
- 관련 이슈: TEST-123
- 병합 대상 브랜치: main
- 업데이트 시간: 2025.05-28 07:50:31

## 작업 요약
---

## 🧾 Overview
이 Pull Request는 `mcp_server.py`에서 GitHub PR 생성 또는 업데이트하는 함수의 입력 방식을 보완합니다.

## 🧩 History

**[현상]**
- 사용자가 이슈 ID와 기준이 될 브랜치명을 명시적으로 입력하지 않을 경우, 이에 대한 안내 메시지만 반환하고 프로그램이 종료되었습니다. 이 경우 사용자는 해당 정보를 입력하려면 프로그램을 다시 시작해야 했습니다.

**[원인]**
- 이슈 ID나 기준 브랜치명이 주어지지 않았을 때, 이를 사용자로부터 직접 요청하는 부분이 누락되어 있었습니다.

**[해결]**
- 이슈 ID나 기준 브랜치명이 누락될 경우, 사용자로부터 해당 정보를 직접 입력받도록 수정하였습니다. 
- `github` 함수에서 이슈 ID가 누락될 경우, 이 문제를 해결하는 코드를 추가하였습니다. 이를 통해 사용자는 이슈 ID를 직접 입력할 수 있게 되었습니다.
- 또한, 기준 브랜치명이 누락되거나 "main"으로 기본 설정될 경우, 사용자로부터 브랜치명을 입력받는 부분을 추가하였습니다.

## 📝 Note
- 수정된 입력 요청 부분의 UX와 해당 부분의 예외 처리를 특히 주의 깊게 리뷰해 주세요.
- 본 수정사항은 사용자의 편의성을 증가시키지만, 올바른 입력을 받았는지 확인하는 부분에 대해 향후 개선이 필요할 수 있습니다.

🔧 자동으로 생성된 내용입니다.

🔧 자동으로 생성된 내용입니다.
<!-- devflow-mcp-end -->